### PR TITLE
Various patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ Patches to afl to fix bugs or add enhancements
 
 **afl-as-AFL_INST_RATIO.diff**			- afl-afl: do not divise by 3 with sanitizer if AFL_INST_RATIO is manually set.  (by legarrec(dot)vincent(at)gmail(dot)com)
 
+**afl-cmin-reduce-dataset.diff**			- afl-cmin: rather small dataset of testcase instead of small testcase.  (by legarrec(dot)vincent(at)gmail(dot)com)
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Patches to afl to fix bugs or add enhancements
 
 **afl-llvm-fix.diff**	- aflc-lang: fix to afl llvm for SIGCHLD in the forkserver (by Kuang-che Wu <kcwu(at)csie(dot)org>)
 
+**afl-sort-all_uniq-fix.diff**	- afl-cmin: fix sort (by legarrec(dot)vincent(at)gmail(dot)com)
+
 
 ### Enhancements / Features
 

--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ Patches to afl to fix bugs or add enhancements
 
 **afl_qemu_optimize_map.diff**			- afl-qemu: removes 2 instructions from afl_log at a cost of 64kb.  (by mh(at)mh-sec(dot)de)
 
+**afl-as-AFL_INST_RATIO.diff**			- afl-afl: do not divise by 3 with sanitizer if AFL_INST_RATIO is manually set.  (by legarrec(dot)vincent(at)gmail(dot)com)
+

--- a/afl-as-AFL_INST_RATIO.diff
+++ b/afl-as-AFL_INST_RATIO.diff
@@ -1,0 +1,12 @@
+--- afl-2.52b/afl-as.c.old	2018-02-11 22:05:48.636563804 +0100
++++ afl-2.52b/afl-as.c	2018-02-11 22:07:04.035919083 +0100
+@@ -525,7 +525,8 @@ int main(int argc, char** argv) {
+ 
+   if (getenv("AFL_USE_ASAN") || getenv("AFL_USE_MSAN")) {
+     sanitizer = 1;
+-    inst_ratio /= 3;
++    if (!getenv("AFL_INST_RATIO"))
++      inst_ratio /= 3;
+   }
+ 
+   if (!just_version) add_instrumentation();

--- a/afl-cmin-reduce-dataset.diff
+++ b/afl-cmin-reduce-dataset.diff
@@ -1,0 +1,38 @@
+--- afl-2.52b/afl-cmin	2018-04-02 10:44:34.273922652 +0200
++++ afl-2.52b/afl-cmin	2018-04-02 11:25:13.310101247 +0200
+@@ -363,10 +363,7 @@ echo "[+] Found $TUPLE_COUNT unique tupl
+ #####################################
+ 
+ # The next step is to find the best candidate for each tuple. The "best"
+-# part is understood simply as the smallest input that includes a particular
+-# tuple in its trace. Empirical evidence suggests that this produces smaller
+-# datasets than more involved algorithms that could be still pulled off in
+-# a shell script.
++# part is understood simply as the input with the biggest bitmap.
+ 
+ echo "[*] Finding best candidates for each tuple..."
+ 
+@@ -379,7 +376,7 @@ while read -r fn; do
+ 
+   sed "s#\$# $fn#" "$TRACE_DIR/$fn" >>"$TRACE_DIR/.candidate_list"
+ 
+-done < <(ls -rS "$IN_DIR")
++done < <(ls -S "$TRACE_DIR")
+ 
+ echo
+ 
+@@ -387,10 +384,10 @@ echo
+ # STEP 4: LOADING CANDIDATES #
+ ##############################
+ 
+-# At this point, we have a file of tuple-file pairs, sorted by file size
+-# in ascending order (as a consequence of ls -rS). By doing sort keyed
+-# only by tuple (-k 1,1) and configured to output only the first line for
+-# every key (-s -u), we end up with the smallest file for each tuple.
++# At this point, we have a file of tuple-file pairs, sorted by biggest test case
++# By doing sort keyed only by tuple (-k 1,1) and configured to output only the
++# first line for every key (-s -u), we end up with the file with largest
++# bitmap for each tuple. To the dataset will be small in number of files.
+ 
+ echo "[*] Sorting candidate list (be patient)..."
+ 

--- a/afl-sort-all_uniq-fix.diff
+++ b/afl-sort-all_uniq-fix.diff
@@ -1,0 +1,11 @@
+--- afl-2.52b/afl-cmin.old	2018-04-02 10:41:58.642001053 +0200
++++ afl-2.52b/afl-cmin	2018-04-02 10:42:07.892098892 +0200
+@@ -352,7 +352,7 @@ echo
+ echo "[*] Sorting trace sets (this may take a while)..."
+ 
+ ls "$IN_DIR" | sed "s#^#$TRACE_DIR/#" | tr '\n' '\0' | xargs -0 -n 1 cat | \
+-  sort | uniq -c | sort -n >"$TRACE_DIR/.all_uniq"
++  sort | uniq -c | sort -k 1,1 -n >"$TRACE_DIR/.all_uniq"
+ 
+ TUPLE_COUNT=$((`grep -c . "$TRACE_DIR/.all_uniq"`))
+ 


### PR DESCRIPTION
1) if AFL_INST_RATIO is set, afl should not divide by 3 under sanitizer.
2) fix a bug in afl-cmin
3) suggestion on afl-cmin: prefer small dataset of testcase instead of small testcase

I already submit 1) and 2) few weeks ago to l_c_a_m_t_u_f@coredump.cx but I didn't had an answer.